### PR TITLE
Migrate FYSETC_MINI_12864_2_1

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#include "../pins/pins_lcd.h"   // Needed to define LED and NEOPIXEL pins on some displays
+
 /**
  * SanityCheck.h
  *

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -170,11 +170,6 @@
   #define BTN_EN2                    EXP2_05_PIN
 
   #if ENABLED(FYSETC_MINI_12864_2_1)
-    // MKS_MINI_12864_V3, BTT_MINI_12864_V1, FYSETC_MINI_12864_2_1
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-    #define LCD_RESET_PIN            EXP1_05_PIN
-    #define NEOPIXEL_PIN             EXP1_06_PIN
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif

--- a/Marlin/src/pins/lcd/FYSETC_MINI_12864_2_1.h
+++ b/Marlin/src/pins/lcd/FYSETC_MINI_12864_2_1.h
@@ -1,0 +1,74 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * pins/lcd/FYSETC_MINI_12864_2_1.h
+ */
+
+// Same as MKS_MINI_12864_V3 and BTT_MINI_12864_V1 with plugs rotated 180 degrees
+
+// U8GLIB_MINI12864_2X_HAL
+
+//  FYSETC_MINI_12864
+//  DOGLCD
+//   HAS_MARLINUI_U8GLIB
+//  IS_ULTIPANEL
+//   HAS_WIRED_LCD
+//    HAS_DISPLAY
+//     HAS_STATUS_MESSAGE
+//   IS_NEWPANEL
+//   HAS_MARLINUI_MENU
+//    HAS_MANUAL_MOVE_MENU
+//  LED_COLORS_REDUCE_GREEN
+
+/**
+ *   FYSECTC Mini 12864 2.1  https://wiki.fysetc.com/Mini12864_Panel/
+ *
+ *
+ *   EXP1                                     EXP2
+ *
+ *   9     7     5     3     1                9     7     5     3     1
+ *   GND   NC    LRST  LCS   BEEP             GND   CD    EN2   EN1   MISO
+ *   VCC   NC    DIN   LRS   ENC              SCK   RST   MOSI  SDSS  SCK
+ *   10    8    (6)    4     2                10    8    (6)    4     2
+ *
+ */
+
+#define BEEPER_PIN        LCD1_01_PIN
+#define BTN_ENC           LCD1_02_PIN
+#define DOGLCD_CS         LCD1_03_PIN
+#define DOGLCD_A0         LCD1_04_PIN
+#define LCD_RESET_PIN     LCD1_05_PIN
+#define NEOPIXEL_PIN      LCD1_06_PIN
+#define DOGLCD_MISO       LCD2_01_PIN
+#define DOGLCD_SCK        LCD2_02_PIN
+#define BTN_EN1           LCD2_03_PIN
+#ifndef SDSS
+  #define SDSS            LCD2_04_PIN
+#endif
+#define BTN_EN2           LCD2_05_PIN
+#define DOGLCD_MOSI       LCD2_06_PIN
+#ifndef SD_DETECT_PIN
+  #define SD_DETECT_PIN   LCD2_07_PIN
+#endif
+#define KILL_PIN          LCD2_08_PIN

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -359,32 +359,8 @@
     #define SD_DETECT_PIN            EXP2_07_PIN  // (49) (NOT 5V tolerant)
 
     #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      #define DOGLCD_SCK             EXP2_02_PIN
-      #define DOGLCD_MOSI            EXP2_06_PIN
-
-      #define LCD_BACKLIGHT_PIN            -1
-
       #define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
-
     #else                                         // !FYSETC_MINI_12864
 
       #if ENABLED(MKS_MINI_12864)

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -336,40 +336,8 @@
 
     #if ENABLED(FYSETC_MINI_12864)
 
-      #define BTN_ENC                EXP1_02_PIN  // (58) open-drain
-      #define BTN_EN1                EXP2_03_PIN  // (31) J3-2 & AUX-4
-      #define BTN_EN2                EXP2_05_PIN  // (33) J3-4 & AUX-4
-
-      #define LCD_PINS_EN            EXP1_03_PIN
-      #define LCD_PINS_RS            EXP1_04_PIN
-      #define LCD_PINS_D4            EXP1_05_PIN
-
-      #define LCD_SDSS               EXP2_04_PIN  // (16) J3-7 & AUX-4
-
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      #define DOGLCD_SCK             EXP2_02_PIN
-      #define DOGLCD_MOSI            EXP2_06_PIN
-
       #define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
-
     #else // !FYSETC_MINI_12864
 
       #if ENABLED(MKS_MINI_12864)

--- a/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
@@ -245,40 +245,6 @@
     #define DOGLCD_MOSI              SD_MOSI_PIN
   #endif
 
-  #if ENABLED(FYSETC_MINI_12864)
-    /**
-     * The FYSETC display can NOT use the SCK and MOSI pins on EXP2, so a
-     * special cable is needed to go between EXP2 on the FYSETC and the
-     * controller board's EXP2 and J8. It also means that a software SPI
-     * is needed to drive those pins.
-     *
-     * The FYSETC requires mode 3 SPI interface.
-     *
-     * Pins 6, 7 & 8 on EXP2 are no connects. That means a second special
-     * cable will be needed if the RGB LEDs are to be active.
-     */
-    #define DOGLCD_CS                      P0_18  // EXP1.3  (LCD_EN on FYSETC schematic)
-    #define DOGLCD_A0                      P0_16  // EXP1.4  (LCD_A0 on FYSETC schematic)
-    #define DOGLCD_SCK                     P2_11  // J8-5  (SCK on FYSETC schematic)
-    #define DOGLCD_MOSI                    P4_28  // J8-6  (MOSI on FYSETC schematic)
-
-    //#define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN              P2_12  // J8-4  (LCD_D6 on FYSETC schematic)
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN              P1_23  // J8-3  (LCD_D5 on FYSETC schematic)
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN              P1_22  // J8-2  (LCD_D7 on FYSETC schematic)
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN                 P2_12
-    #endif
-
   #elif ENABLED(MINIPANEL)
     //#define LCD_SCREEN_ROTATE              180  // 0, 90, 180, 270
   #endif

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -354,32 +354,8 @@
 
       #if ENABLED(FYSETC_MINI_12864)
 
-        #define DOGLCD_CS            EXP1_03_PIN
-        #define DOGLCD_A0            EXP1_04_PIN
-        #define DOGLCD_SCK           EXP2_02_PIN
-        #define DOGLCD_MOSI          EXP2_06_PIN
-
-        #define LCD_BACKLIGHT_PIN          -1
-
         #define FORCE_SOFT_SPI                    // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-        #define LCD_RESET_PIN        EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-        #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-          #ifndef RGB_LED_R_PIN
-            #define RGB_LED_R_PIN    EXP1_06_PIN
-          #endif
-          #ifndef RGB_LED_G_PIN
-            #define RGB_LED_G_PIN    EXP1_07_PIN
-          #endif
-          #ifndef RGB_LED_B_PIN
-            #define RGB_LED_B_PIN    EXP1_08_PIN
-          #endif
-        #elif ENABLED(FYSETC_MINI_12864_2_1)
-          #define NEOPIXEL_PIN       EXP1_06_PIN
-        #endif
-
       #else                                       // !FYSETC_MINI_12864
 
         #if ENABLED(MKS_MINI_12864)

--- a/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
@@ -323,14 +323,9 @@
 
 #elif HAS_WIRED_LCD
 
-  #if ENABLED(FYSETC_MINI_12864)
-    #define BEEPER_PIN                     P1_01
-    #define BTN_ENC                        P1_04
-  #else
-    #define BEEPER_PIN                     P1_30  // (37) not 5V tolerant
-    #define BTN_ENC                        P2_11  // (35) J3-3 & AUX-4
-  #endif
-
+  #define BEEPER_PIN                     P1_30  // (37) not 5V tolerant
+  #define BTN_ENC                        P2_11  // (35) J3-3 & AUX-4
+ 
   #define BTN_EN1                          P3_26  // (31) J3-2 & AUX-4
   #define BTN_EN2                          P3_25  // (33) J3-4 & AUX-4
 
@@ -365,35 +360,8 @@
 
   #else
 
-    #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_SCK                   P0_15
-      #define DOGLCD_MOSI                  P0_18
-
-      // EXP1 on LCD adapter is not usable - using Ethernet connector instead
-      #define DOGLCD_CS                    P1_09
-      #define DOGLCD_A0                    P1_14
-      //#define FORCE_SOFT_SPI                    // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-      #define LCD_RESET_PIN                P0_16  // Must be high or open for LCD to operate normally.
-
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN            P1_00
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN            P1_01
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN            P1_08
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN               P1_00
-      #endif
-    #else
-      #define DOGLCD_CS                    P0_26  // (63) J5-3 & AUX-2
-      #define DOGLCD_A0                    P2_06  // (59) J3-8 & AUX-2
-    #endif
+    #define DOGLCD_CS                    P0_26  // (63) J5-3 & AUX-2
+    #define DOGLCD_A0                    P2_06  // (59) J3-8 & AUX-2
 
     #define LCD_BACKLIGHT_PIN              P0_16  //(16) J3-7 & AUX-4 - only used on DOGLCD controllers
     #define LCD_PINS_EN                    P0_18  // (51) (MOSI) J3-10 & AUX-3

--- a/Marlin/src/pins/lpc1769/pins_COHESION3D_REMIX.h
+++ b/Marlin/src/pins/lpc1769/pins_COHESION3D_REMIX.h
@@ -200,8 +200,6 @@
     #ifndef RGB_LED_B_PIN
       #define RGB_LED_B_PIN                P1_00  // EXP1-8  =>  Ethernet pin 12 (top row, 6 from left)
     #endif
-  #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define NEOPIXEL_PIN                   P1_16  // EXP1-6  =>  Ethernet pin  6 (top row, 3 from left)
   #endif
 
 #elif HAS_WIRED_LCD

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -369,31 +369,8 @@
 
     #if ENABLED(FYSETC_MINI_12864)
 
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      #define DOGLCD_SCK             EXP2_02_PIN
-      #define DOGLCD_MOSI            EXP2_06_PIN
-
-      #define LCD_BACKLIGHT_PIN            -1
-
       #define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
 
     #else                                         // !FYSETC_MINI_12864
 

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -119,20 +119,6 @@
       #define DOGLCD_CS                       21
       #define BTN_EN1                         40
       #define BTN_EN2                         42
-    #elif ENABLED(FYSETC_MINI_12864)
-      // Disconnect EXP2-1 and EXP2-2, otherwise future firmware upload won't work.
-      #define DOGLCD_A0                       20
-      #define DOGLCD_CS                       17
-
-      #define NEOPIXEL_PIN                    21
-      #define BTN_EN1                         42
-      #define BTN_EN2                         40
-
-      #define LCD_RESET_PIN                   16
-
-      #define LCD_CONTRAST_INIT              220
-
-      #define LCD_BACKLIGHT_PIN               -1
     #else
       #define LCD_PINS_RS                     20
       #define LCD_PINS_EN                     17

--- a/Marlin/src/pins/pins_lcd.h
+++ b/Marlin/src/pins/pins_lcd.h
@@ -49,6 +49,8 @@
     #include "lcd/RRD_FG_SC.h"
   #elif IS_RRD_SC
     #include "lcd/RRD_SC.h"
+  #elif ANY(FYSETC_MINI_12864_2_1,MKS_MINI_12864_V3,BTT_MINI_12864_V1)
+    #include "lcd/FYSETC_MINI_12864_2_1.h"
   #else
 
     // More displays to come

--- a/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
+++ b/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
@@ -253,35 +253,7 @@
 #else
   #define BEEPER_PIN                 EXP1_01_PIN
 
-  #if ENABLED(FYSETC_MINI_12864)
-    //
-    // See https://wiki.fysetc.com/Mini12864_Panel/
-    //
-    #define DOGLCD_A0                EXP1_04_PIN
-    #define DOGLCD_CS                EXP1_03_PIN
-
-    #if ENABLED(FYSETC_GENERIC_12864_1_1)
-      #define LCD_BACKLIGHT_PIN      EXP1_07_PIN
-    #endif
-
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-                                                  // Seems to work best if left open.
-
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
-    #endif
-
-  #elif HAS_MARLINUI_U8GLIB || HAS_MARLINUI_HD44780
+  #if HAS_MARLINUI_U8GLIB || HAS_MARLINUI_HD44780
 
     #define LCD_PINS_RS              EXP1_04_PIN
     #define LCD_PINS_EN              EXP1_03_PIN

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -650,7 +650,7 @@
         #define DOGLCD_SCK           EXP1_05_PIN
       #else
         #define LCD_PINS_RS          EXP1_04_PIN
-        #define LCD_PINS_EN          EXP1_03_PIN
+        //#define LCD_PINS_EN          EXP1_03_PIN
         #define LCD_PINS_D4          EXP1_05_PIN
         #define LCD_PINS_D5          EXP1_06_PIN
         #define LCD_PINS_D6          EXP1_07_PIN
@@ -770,7 +770,7 @@
       #endif
       #define KILL_PIN               EXP2_08_PIN
 
-    #elif EITHER(MKS_MINI_12864, FYSETC_MINI_12864)
+    #elif ENABLED(MKS_MINI_12864)
 
       #define BTN_ENC                EXP1_02_PIN
       #ifndef SD_DETECT_PIN
@@ -781,47 +781,14 @@
         #define KILL_PIN             EXP2_08_PIN
       #endif
 
-      #if ENABLED(MKS_MINI_12864)
+      #define DOGLCD_A0            EXP1_07_PIN
+      #define DOGLCD_CS            EXP1_06_PIN
 
-        #define DOGLCD_A0            EXP1_07_PIN
-        #define DOGLCD_CS            EXP1_06_PIN
+      // not connected to a pin
+      #define LCD_BACKLIGHT_PIN             -1  // 65 (MKS mini12864 can't adjust backlight by software!)
 
-        // not connected to a pin
-        #define LCD_BACKLIGHT_PIN             -1  // 65 (MKS mini12864 can't adjust backlight by software!)
-
-        #define BTN_EN1              EXP2_03_PIN
-        #define BTN_EN2              EXP2_05_PIN
-
-      #elif ENABLED(FYSETC_MINI_12864)
-
-        // From https://wiki.fysetc.com/Mini12864_Panel/
-
-        #define DOGLCD_A0            EXP1_04_PIN
-        #define DOGLCD_CS            EXP1_03_PIN
-
-        #define BTN_EN1              EXP2_05_PIN
-        #define BTN_EN2              EXP2_03_PIN
-
-        //#define FORCE_SOFT_SPI                  // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-        #define LCD_RESET_PIN        EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-        #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-          #ifndef RGB_LED_R_PIN
-            #define RGB_LED_R_PIN    EXP1_06_PIN
-          #endif
-          #ifndef RGB_LED_G_PIN
-            #define RGB_LED_G_PIN    EXP1_07_PIN
-          #endif
-          #ifndef RGB_LED_B_PIN
-            #define RGB_LED_B_PIN    EXP1_08_PIN
-          #endif
-        #elif ENABLED(FYSETC_MINI_12864_2_1)
-          #define NEOPIXEL_PIN       EXP1_06_PIN
-        #endif
-
-      #endif
+      #define BTN_EN1              EXP2_03_PIN
+      #define BTN_EN2              EXP2_05_PIN
 
     #elif ENABLED(MINIPANEL)
 
@@ -870,7 +837,7 @@
     #else
 
       #ifndef BEEPER_PIN
-        #define BEEPER_PIN           EXP2_05_PIN
+        //#define BEEPER_PIN           EXP2_05_PIN
       #endif
 
       #if ENABLED(PANEL_ONE)                      // Buttons connect directly to AUX-2
@@ -878,16 +845,16 @@
         #define BTN_EN2                  AUX2_04
         #define BTN_ENC                  AUX3_02
       #else
-        #define BTN_EN1              EXP1_01_PIN
-        #define BTN_EN2              EXP1_02_PIN
-        #define BTN_ENC              EXP2_03_PIN
+        //#define BTN_EN1              EXP1_01_PIN
+        //#define BTN_EN2              EXP1_02_PIN
+        //#define BTN_ENC              EXP2_03_PIN
       #endif
 
     #endif
   #endif // IS_NEWPANEL
 
   #ifndef BEEPER_PIN
-    #define BEEPER_PIN               EXP1_01_PIN  // Most common mapping
+   // #define BEEPER_PIN               EXP1_01_PIN  // Most common mapping
   #endif
 
 #endif // HAS_WIRED_LCD && !LCD_PINS_DEFINED

--- a/Marlin/src/pins/ramps/pins_RUMBA.h
+++ b/Marlin/src/pins/ramps/pins_RUMBA.h
@@ -198,31 +198,6 @@
   #define DOGLCD_MOSI                         42
   #define DOGLCD_SCK                          18
   #define DOGLCD_A0                  LCD_PINS_DC
-#elif ENABLED(FYSETC_MINI_12864)
-  #define DOGLCD_CS                           42
-  #define DOGLCD_A0                           19
-  #define DOGLCD_MOSI                         51
-  #define DOGLCD_SCK                          52
-
-  //#define FORCE_SOFT_SPI                        // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-  #define LCD_RESET_PIN                       18  // Must be high or open for LCD to operate normally.
-
-  #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-    #ifndef RGB_LED_R_PIN
-      #define RGB_LED_R_PIN                   41
-    #endif
-    #ifndef RGB_LED_G_PIN
-      #define RGB_LED_G_PIN                   38
-    #endif
-    #ifndef RGB_LED_B_PIN
-      #define RGB_LED_B_PIN                   40
-    #endif
-  #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define NEOPIXEL_PIN                      38
-  #endif
-
 #else
   #define LCD_PINS_RS                         19
   #define LCD_PINS_EN                         42

--- a/Marlin/src/pins/sam/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_FD_V1.h
@@ -184,32 +184,7 @@
     #define LCD_PINS_EN              EXP1_08_PIN
   #endif
 
-  #if ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                EXP1_08_PIN
-    #define DOGLCD_A0                EXP1_07_PIN
-    #define DOGLCD_SCK               EXP2_02_PIN
-    #define DOGLCD_MOSI              EXP2_06_PIN
-
-    //#define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-    #define LCD_RESET_PIN            EXP1_06_PIN  // Must be high or open for LCD to operate normally.
-
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_05_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_04_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_03_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_05_PIN
-    #endif
-
-  #elif IS_NEWPANEL
+  #if IS_NEWPANEL
 
     #define LCD_PINS_D4              EXP1_06_PIN
     #define LCD_PINS_D5              EXP1_05_PIN

--- a/Marlin/src/pins/sam/pins_RURAMPS4D_11.h
+++ b/Marlin/src/pins/sam/pins_RURAMPS4D_11.h
@@ -243,31 +243,6 @@
     #define LCD_SDSS                 EXP2_04_PIN
     #define SD_DETECT_PIN            EXP2_07_PIN
 
-  #elif ENABLED(FYSETC_MINI_12864)
-
-    #define BEEPER_PIN               EXP1_01_PIN
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-
-    //#define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN  // D5
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN  // D6
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN  // D7
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN  // D5
-    #endif
-
   #elif ENABLED(SPARK_FULL_GRAPHICS)
 
     //http://doku.radds.org/dokumentation/other-electronics/sparklcd/

--- a/Marlin/src/pins/sam/pins_RURAMPS4D_13.h
+++ b/Marlin/src/pins/sam/pins_RURAMPS4D_13.h
@@ -233,31 +233,6 @@
     #define LCD_SDSS                 EXP2_04_PIN
     #define SD_DETECT_PIN            EXP2_07_PIN
 
-  #elif ENABLED(FYSETC_MINI_12864)
-
-    #define BEEPER_PIN               EXP1_01_PIN
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-
-    //#define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN  // D5
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN  // D6
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN  // D7
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN  // D5
-    #endif
-
   #elif ENABLED(MKS_MINI_12864)
     #define DOGLCD_A0                EXP1_07_PIN
     #define DOGLCD_CS                EXP1_06_PIN

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -377,7 +377,7 @@
       //#define SD_DETECT_PIN        EXP2_10_PIN
       //#define KILL_PIN             EXP1_01_PIN
 
-    #elif EITHER(MKS_MINI_12864, FYSETC_MINI_12864)
+    #elif ENBALED(MKS_MINI_12864)
 
       // TO TEST
       //#define BEEPER_PIN           EXP1_06_PIN
@@ -388,59 +388,20 @@
       //  #define KILL_PIN           EXP1_01_PIN
       //#endif
 
-      #if ENABLED(MKS_MINI_12864)
+      //#define DOGLCD_A0                   27
+      //#define DOGLCD_CS                   25
 
-        // TO TEST
-        //#define DOGLCD_A0                   27
-        //#define DOGLCD_CS                   25
+      // GLCD features
+      // Uncomment screen orientation
+      //#define LCD_SCREEN_ROT_90
+      //#define LCD_SCREEN_ROT_180
+      //#define LCD_SCREEN_ROT_270
 
-        // GLCD features
-        // Uncomment screen orientation
-        //#define LCD_SCREEN_ROT_90
-        //#define LCD_SCREEN_ROT_180
-        //#define LCD_SCREEN_ROT_270
+      // not connected to a pin
+      //#define LCD_BACKLIGHT_PIN           57  // backlight LED on A11/D? (Mega/Due:65 - AGCM4:57)
 
-        // not connected to a pin
-        //#define LCD_BACKLIGHT_PIN           57  // backlight LED on A11/D? (Mega/Due:65 - AGCM4:57)
-
-        //#define BTN_EN1                     31
-        //#define BTN_EN2                     33
-
-      #elif ENABLED(FYSETC_MINI_12864)
-
-        // From https://wiki.fysetc.com/Mini12864_Panel/
-
-        // TO TEST
-        //#define DOGLCD_A0                   16
-        //#define DOGLCD_CS                   17
-
-        //#define BTN_EN1                     33
-        //#define BTN_EN2                     31
-
-        //#define FORCE_SOFT_SPI                  // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-        //#define LCD_RESET_PIN               23  // Must be high or open for LCD to operate normally.
-
-        #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-          #ifndef RGB_LED_R_PIN
-            // TO TEST
-            //#define RGB_LED_R_PIN           25
-          #endif
-          #ifndef RGB_LED_G_PIN
-            // TO TEST
-            //#define RGB_LED_G_PIN           27
-          #endif
-          #ifndef RGB_LED_B_PIN
-            // TO TEST
-            //#define RGB_LED_B_PIN           29
-          #endif
-        #elif ENABLED(FYSETC_MINI_12864_2_1)
-          // TO TEST
-          //#define NEOPIXEL_PIN              25
-        #endif
-
-      #endif
+      //#define BTN_EN1                     31
+      //#define BTN_EN2                     33
 
     #elif ENABLED(MINIPANEL)
 

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -463,41 +463,6 @@
         //#define BTN_EN1                     31
         //#define BTN_EN2                     33
 
-      #elif ENABLED(FYSETC_MINI_12864)
-
-        // From https://wiki.fysetc.com/Mini12864_Panel/
-
-        // TO TEST
-        //#define DOGLCD_A0                   16
-        //#define DOGLCD_CS                   17
-
-        //#define BTN_EN1                     33
-        //#define BTN_EN2                     31
-
-        //#define FORCE_SOFT_SPI                  // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-        //#define LCD_RESET_PIN               23  // Must be high or open for LCD to operate normally.
-
-        #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-          #ifndef RGB_LED_R_PIN
-            // TO TEST
-            //#define RGB_LED_R_PIN           25
-          #endif
-          #ifndef RGB_LED_G_PIN
-            // TO TEST
-            //#define RGB_LED_G_PIN           27
-          #endif
-          #ifndef RGB_LED_B_PIN
-            // TO TEST
-            //#define RGB_LED_B_PIN           29
-          #endif
-        #elif ENABLED(FYSETC_MINI_12864_2_1)
-          // TO TEST
-          //#define NEOPIXEL_PIN              25
-        #endif
-
-      #endif
 
     #elif ENABLED(MINIPANEL)
 

--- a/Marlin/src/pins/samd/pins_MINITRONICS20.h
+++ b/Marlin/src/pins/samd/pins_MINITRONICS20.h
@@ -328,7 +328,7 @@
       //#define SD_DETECT_PIN        EXP2_10_PIN
       //#define KILL_PIN             EXP1_01_PIN
 
-    #elif EITHER(MKS_MINI_12864, FYSETC_MINI_12864)
+    #elif ENABLED(MKS_MINI_12864)
 
       // TO TEST
       //#define BEEPER_PIN           EXP1_06_PIN
@@ -339,59 +339,20 @@
       //  #define KILL_PIN           EXP1_01_PIN
       //#endif
 
-      #if ENABLED(MKS_MINI_12864)
+      //#define DOGLCD_A0                   27
+      //#define DOGLCD_CS                   25
 
-        // TO TEST
-        //#define DOGLCD_A0                   27
-        //#define DOGLCD_CS                   25
+      // GLCD features
+      // Uncomment screen orientation
+      //#define LCD_SCREEN_ROT_90
+      //#define LCD_SCREEN_ROT_180
+      //#define LCD_SCREEN_ROT_270
 
-        // GLCD features
-        // Uncomment screen orientation
-        //#define LCD_SCREEN_ROT_90
-        //#define LCD_SCREEN_ROT_180
-        //#define LCD_SCREEN_ROT_270
+      // not connected to a pin
+      //#define LCD_BACKLIGHT_PIN           57  // backlight LED on A11/D? (Mega/Due:65 - AGCM4:57)
 
-        // not connected to a pin
-        //#define LCD_BACKLIGHT_PIN           57  // backlight LED on A11/D? (Mega/Due:65 - AGCM4:57)
-
-        //#define BTN_EN1                     31
-        //#define BTN_EN2                     33
-
-      #elif ENABLED(FYSETC_MINI_12864)
-
-        // From https://wiki.fysetc.com/Mini12864_Panel/
-
-        // TO TEST
-        //#define DOGLCD_A0                   16
-        //#define DOGLCD_CS                   17
-
-        //#define BTN_EN1                     33
-        //#define BTN_EN2                     31
-
-        //#define FORCE_SOFT_SPI                  // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-        //#define LCD_RESET_PIN               23  // Must be high or open for LCD to operate normally.
-
-        #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-          #ifndef RGB_LED_R_PIN
-            // TO TEST
-            //#define RGB_LED_R_PIN           25
-          #endif
-          #ifndef RGB_LED_G_PIN
-            // TO TEST
-            //#define RGB_LED_G_PIN           27
-          #endif
-          #ifndef RGB_LED_B_PIN
-            // TO TEST
-            //#define RGB_LED_B_PIN           29
-          #endif
-        #elif ENABLED(FYSETC_MINI_12864_2_1)
-          // TO TEST
-          //#define NEOPIXEL_PIN              25
-        #endif
-
-      #endif
+      //#define BTN_EN1                     31
+      //#define BTN_EN2                     33
 
     #elif ENABLED(MINIPANEL)
 

--- a/Marlin/src/pins/samd/pins_RAMPS_144.h
+++ b/Marlin/src/pins/samd/pins_RAMPS_144.h
@@ -627,37 +627,6 @@
         #define BTN_EN1              EXP2_03_PIN
         #define BTN_EN2              EXP2_05_PIN
 
-      #elif ENABLED(FYSETC_MINI_12864)
-
-        // From https://wiki.fysetc.com/Mini12864_Panel/
-
-        #define DOGLCD_A0            EXP1_04_PIN
-        #define DOGLCD_CS            EXP1_03_PIN
-
-        #define BTN_EN1              EXP2_05_PIN
-        #define BTN_EN2              EXP2_03_PIN
-
-        //#define FORCE_SOFT_SPI                  // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-        #define LCD_RESET_PIN        EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-        #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-          #ifndef RGB_LED_R_PIN
-            #define RGB_LED_R_PIN    EXP1_06_PIN
-          #endif
-          #ifndef RGB_LED_G_PIN
-            #define RGB_LED_G_PIN    EXP1_07_PIN
-          #endif
-          #ifndef RGB_LED_B_PIN
-            #define RGB_LED_B_PIN    EXP1_08_PIN
-          #endif
-        #elif ENABLED(FYSETC_MINI_12864_2_1)
-          #define NEOPIXEL_PIN       EXP1_06_PIN
-        #endif
-
-      #endif
-
     #elif ENABLED(MINIPANEL)
 
       #define BEEPER_PIN                 AUX2_08

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_V1_1.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_V1_1.h
@@ -202,33 +202,7 @@
     #define LCD_PINS_EN              EXP1_03_PIN
 
     #if ENABLED(FYSETC_MINI_12864)
-
-      #define LCD_BACKLIGHT_PIN             -1
-      #define LCD_RESET_PIN          EXP1_05_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_SCK             EXP2_02_PIN
-      #define DOGLCD_MOSI            EXP2_06_PIN
-
       #define FORCE_SOFT_SPI                      // SPI MODE3
-
-      #define LED_PIN                EXP1_06_PIN  // red pwm
-      //#define LED_PIN              EXP1_07_PIN  // green
-      //#define LED_PIN              EXP1_08_PIN  // blue
-
-      //#if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      //  #ifndef RGB_LED_R_PIN
-      //    #define RGB_LED_R_PIN    EXP1_06_PIN
-      //  #endif
-      //  #ifndef RGB_LED_G_PIN
-      //    #define RGB_LED_G_PIN    EXP1_07_PIN
-      //  #endif
-      //  #ifndef RGB_LED_B_PIN
-      //    #define RGB_LED_B_PIN    EXP1_08_PIN
-      //  #endif
-      //#elif ENABLED(FYSETC_MINI_12864_2_1)
-      //  #define NEOPIXEL_PIN       EXP1_06_PIN
-      //#endif
 
     #else                                         // !FYSETC_MINI_12864
 

--- a/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
+++ b/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
@@ -215,32 +215,7 @@
 
     #if ENABLED(FYSETC_MINI_12864)
 
-      #define LCD_BACKLIGHT_PIN             -1
-      #define LCD_RESET_PIN          EXP1_06_PIN
-      #define DOGLCD_A0              EXP1_07_PIN
-      #define DOGLCD_CS              EXP1_08_PIN
-      #define DOGLCD_SCK             EXP2_09_PIN
-      #define DOGLCD_MOSI            EXP2_05_PIN
-
       #define FORCE_SOFT_SPI                      // SPI MODE3
-
-      #define LED_PIN                EXP1_05_PIN   // red pwm
-      //#define LED_PIN              EXP1_04_PIN  // green
-      //#define LED_PIN              EXP1_03_PIN  // blue
-
-      //#if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      //  #ifndef RGB_LED_R_PIN
-      //    #define RGB_LED_R_PIN    EXP1_05_PIN
-      //  #endif
-      //  #ifndef RGB_LED_G_PIN
-      //    #define RGB_LED_G_PIN    EXP1_04_PIN
-      //  #endif
-      //  #ifndef RGB_LED_B_PIN
-      //    #define RGB_LED_B_PIN    EXP1_03_PIN
-      //  #endif
-      //#elif ENABLED(FYSETC_MINI_12864_2_1)
-      //  #define NEOPIXEL_PIN       EXP1_05_PIN
-      //#endif
 
     #else                                         // !FYSETC_MINI_12864
 

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -343,14 +343,6 @@
     #endif
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define LCD_PINS_DC              EXP1_04_PIN
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                  DOGLCD_A0
-    #define LCD_BACKLIGHT_PIN               -1
-    #define LCD_RESET_PIN            EXP1_05_PIN
-    #define NEOPIXEL_PIN             EXP1_06_PIN
-    #define DOGLCD_MOSI              EXP2_06_PIN
-    #define DOGLCD_SCK               EXP2_02_PIN
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -200,15 +200,6 @@
     #define DOGLCD_MOSI              EXP2_06_PIN
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
-
-    #define LCD_PINS_DC              EXP1_04_PIN
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                LCD_PINS_DC
-    #define LCD_BACKLIGHT_PIN               -1
-    #define LCD_RESET_PIN            EXP1_05_PIN
-    #define NEOPIXEL_PIN             EXP1_06_PIN
-    #define DOGLCD_MOSI              EXP2_06_PIN
-    #define DOGLCD_SCK               EXP2_02_PIN
     #define FORCE_SOFT_SPI
     #define SOFTWARE_SPI
     //#define LCD_SCREEN_ROTATE              180  // 0, 90, 180, 270

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -343,14 +343,6 @@
     #endif
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define LCD_PINS_DC                     PC6
-    #define DOGLCD_CS                       PD13
-    #define DOGLCD_A0                  DOGLCD_A0
-    #define LCD_BACKLIGHT_PIN               -1
-    #define LCD_RESET_PIN                   PE14
-    #define NEOPIXEL_PIN                    PE15
-    #define DOGLCD_MOSI                     PA7
-    #define DOGLCD_SCK                      PA5
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif

--- a/Marlin/src/pins/stm32f4/pins_ARMED.h
+++ b/Marlin/src/pins/stm32f4/pins_ARMED.h
@@ -147,42 +147,16 @@
 #define SD_DETECT_PIN                       PA15
 #define BEEPER_PIN                          PC9
 
-#if ENABLED(FYSETC_MINI_12864)
-  //
-  // See https://wiki.fysetc.com/Mini12864_Panel/
-  //
-  #define DOGLCD_A0                         PE9
-  #define DOGLCD_CS                         PE8
+#define LCD_PINS_RS                       PE9
+#define LCD_PINS_EN                       PE8
+#define LCD_PINS_D4                       PB12
+#define LCD_PINS_D5                       PB13
+#define LCD_PINS_D6                       PB14
+#define LCD_PINS_D7                       PB15
 
-  #define LCD_BACKLIGHT_PIN                 -1
-
-  #define LCD_RESET_PIN                     PB12  // Must be high or open for LCD to operate normally.
-
-  #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-    #ifndef RGB_LED_R_PIN
-      #define RGB_LED_R_PIN                 PB13
-    #endif
-    #ifndef RGB_LED_G_PIN
-      #define RGB_LED_G_PIN                 PB14
-    #endif
-    #ifndef RGB_LED_B_PIN
-      #define RGB_LED_B_PIN                 PB15
-    #endif
-  #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define NEOPIXEL_PIN                    PB13
-  #endif
-#else
-  #define LCD_PINS_RS                       PE9
-  #define LCD_PINS_EN                       PE8
-  #define LCD_PINS_D4                       PB12
-  #define LCD_PINS_D5                       PB13
-  #define LCD_PINS_D6                       PB14
-  #define LCD_PINS_D7                       PB15
-
-  #if ENABLED(MKS_MINI_12864)
-    #define DOGLCD_CS                       PB13
-    #define DOGLCD_A0                       PB14
-  #endif
+#if ENABLED(MKS_MINI_12864)
+  #define DOGLCD_CS                       PB13
+  #define DOGLCD_A0                       PB14
 #endif
 
 #define BTN_EN1                             PC4

--- a/Marlin/src/pins/stm32f4/pins_ARTILLERY_RUBY.h
+++ b/Marlin/src/pins/stm32f4/pins_ARTILLERY_RUBY.h
@@ -134,30 +134,6 @@
     #define DOGLCD_MOSI                     PB6
     #define DOGLCD_SCK                      PB5
     #define DOGLCD_A0                LCD_PINS_DC
-  #elif ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                       PB6
-    #define DOGLCD_A0                       PC15
-
-    //#define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-    #define LCD_RESET_PIN                   PB5   // Must be high or open for LCD to operate normally.
-
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN               PB9
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN               PB8
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN               PB7
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN                  PB9
-    #endif
-
-    #define LCD_CONTRAST_INIT                255
   #else
     #define LCD_PINS_RS                     PC15
     #define LCD_PINS_EN                     PB6

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -270,31 +270,8 @@
     #define LCD_PINS_D4              EXP1_05_PIN
 
     #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      #define DOGLCD_MOSI            EXP2_06_PIN
-      #define DOGLCD_MISO            EXP2_01_PIN
-      #define DOGLCD_SCK             EXP2_02_PIN
-
-      #define LCD_BACKLIGHT_PIN             -1
-
       #define FORCE_SOFT_SPI
 
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
     #endif // !FYSETC_MINI_12864
 
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -450,29 +450,9 @@
     #define LCD_PINS_D4              EXP1_05_PIN
 
     #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-
       #if SD_CONNECTION_IS(ONBOARD)
         #define SOFTWARE_SPI
       #endif
-
-      //#define LCD_BACKLIGHT_PIN           -1
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
-    #endif // !FYSETC_MINI_12864
 
     #if IS_ULTIPANEL
       #define LCD_PINS_D5            EXP1_06_PIN

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -453,25 +453,6 @@
   #define BTN_EN2                    EXP2_05_PIN
   #define BTN_ENC                    EXP1_02_PIN
 
-  #if ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-    //#define LCD_BACKLIGHT_PIN             -1
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
-    #endif
-  #endif // !FYSETC_MINI_12864
 
   #if IS_ULTIPANEL
     #define LCD_PINS_D5              EXP1_06_PIN

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -494,26 +494,6 @@
     #define LCD_PINS_EN              EXP1_03_PIN
     #define LCD_PINS_D4              EXP1_05_PIN
 
-    #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      //#define LCD_BACKLIGHT_PIN           -1
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
-    #endif // !FYSETC_MINI_12864
-
     #if IS_ULTIPANEL
       #define LCD_PINS_D5            EXP1_06_PIN
       #define LCD_PINS_D6            EXP1_07_PIN

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -466,26 +466,6 @@
   #define LCD_PINS_EN                EXP1_03_PIN
   #define LCD_PINS_D4                EXP1_05_PIN
 
-  #if ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-    //#define LCD_BACKLIGHT_PIN             -1
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
-    #endif
-  #endif // !FYSETC_MINI_12864
-
   #if IS_ULTIPANEL
     #define LCD_PINS_D5              EXP1_06_PIN
     #define LCD_PINS_D6              EXP1_07_PIN

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V20.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V20.h
@@ -209,26 +209,6 @@
   #define LCD_PINS_EN                EXP1_03_PIN
   #define LCD_PINS_D4                EXP1_05_PIN
 
-  #if ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-    //#define LCD_BACKLIGHT_PIN             -1
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
-    #endif
-  #endif // !FYSETC_MINI_12864
-
   #if IS_ULTIPANEL
     #define LCD_PINS_D5              EXP1_06_PIN
     #define LCD_PINS_D6              EXP1_07_PIN

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -277,25 +277,8 @@
   #define LCD_PINS_D4                EXP1_05_PIN
 
   #if ENABLED(FYSETC_MINI_12864)
-    // See https://wiki.fysetc.com/Mini12864_Panel
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
     #if ENABLED(FYSETC_GENERIC_12864_1_1)
       #define LCD_BACKLIGHT_PIN      EXP1_07_PIN
-    #endif
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
     #endif
   #endif
 

--- a/Marlin/src/pins/stm32f4/pins_I3DBEEZ9.h
+++ b/Marlin/src/pins/stm32f4/pins_I3DBEEZ9.h
@@ -555,26 +555,6 @@
     #define LCD_PINS_EN              EXP1_03_PIN
     #define LCD_PINS_D4              EXP1_05_PIN
 
-    #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      //#define LCD_BACKLIGHT_PIN           -1
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
-    #endif // !FYSETC_MINI_12864
-
     #if IS_ULTIPANEL
       #define LCD_PINS_D5            EXP1_06_PIN
       #define LCD_PINS_D6            EXP1_07_PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
@@ -332,14 +332,6 @@
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
 
-    #define LCD_PINS_DC              EXP1_04_PIN
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                LCD_PINS_DC
-    #define LCD_BACKLIGHT_PIN               -1
-    #define LCD_RESET_PIN            EXP1_05_PIN
-    #define NEOPIXEL_PIN             EXP1_06_PIN
-    #define DOGLCD_MOSI              EXP2_06_PIN
-    #define DOGLCD_SCK               EXP2_02_PIN
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -346,14 +346,6 @@
     //#define MKS_LCD12864B
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define LCD_PINS_DC              EXP1_04_PIN
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                LCD_PINS_DC
-    #define LCD_BACKLIGHT_PIN               -1
-    #define LCD_RESET_PIN            EXP1_05_PIN
-    #define NEOPIXEL_PIN             EXP1_06_PIN
-    #define DOGLCD_MOSI              EXP2_06_PIN
-    #define DOGLCD_SCK               EXP2_02_PIN
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
@@ -297,26 +297,6 @@
   #define BTN_EN2                    EXP2_05_PIN
   #define BTN_ENC                    EXP1_02_PIN
 
-  #if ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-    //#define LCD_BACKLIGHT_PIN             -1
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
-    #endif
-  #endif // !FYSETC_MINI_12864
-
   #if IS_ULTIPANEL
     #define LCD_PINS_D5              EXP1_06_PIN
     #define LCD_PINS_D6              EXP1_07_PIN

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V1_0.h
@@ -239,27 +239,9 @@
   #define LCD_PINS_D4                EXP1_05_PIN
 
   #if ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-    //#define LCD_BACKLIGHT_PIN             -1
-
     #define FORCE_SOFT_SPI                        // Use this if default of hardware SPI causes display problems
                                                   // results in LCD soft SPI mode 3, SD soft SPI mode 0
 
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
-    #endif
   #endif // !FYSETC_MINI_12864
 
   #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M5P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M5P_V1_0.h
@@ -273,27 +273,8 @@
     #define LCD_PINS_D4              EXP1_05_PIN
 
     #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      //#define LCD_BACKLIGHT_PIN           -1
-
       #define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
     #endif // !FYSETC_MINI_12864
 
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
@@ -323,27 +323,8 @@
     #define LCD_PINS_D4              EXP1_05_PIN
 
     #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      //#define LCD_BACKLIGHT_PIN           -1
-
       #define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
     #endif // !FYSETC_MINI_12864
 
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
@@ -421,29 +421,9 @@
   #define BTN_ENC                    EXP1_02_PIN
 
   #if ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-    #define DOGLCD_SCK               EXP2_02_PIN
-    #define DOGLCD_MOSI              EXP2_06_PIN
-
     #define SOFTWARE_SPI
     #define FORCE_SOFT_SPI                        // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-    //#define LCD_BACKLIGHT_PIN             -1
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
-    #endif
   #endif // !FYSETC_MINI_12864
 
   #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -462,25 +462,6 @@
   #define LCD_PINS_RS                EXP1_04_PIN
   #define LCD_PINS_D4                EXP1_05_PIN
 
-  #if ENABLED(FYSETC_MINI_12864)
-    #define DOGLCD_CS                EXP1_03_PIN
-    #define DOGLCD_A0                EXP1_04_PIN
-    //#define LCD_BACKLIGHT_PIN             -1
-    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-      #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN        EXP1_06_PIN
-      #endif
-      #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN        EXP1_07_PIN
-      #endif
-      #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN        EXP1_08_PIN
-      #endif
-    #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN           EXP1_06_PIN
-    #endif
-  #endif // !FYSETC_MINI_12864
 
   #if IS_ULTIPANEL
     #define LCD_PINS_D5              EXP1_06_PIN


### PR DESCRIPTION
### Description

My attempt to Migrate  fysetc mini 12864 2 1

Some preliminary work for  FYSETC_MINI_12864_1_2  and FYSETC_MINI_12864_2_0 also   (removed from pins files) 
These are coming soon.

Had to remove some defaults from Marlin/src/pins/ramps/pins_RAMPS.h  so some lcds will not compile till migrated.

Tested on ramps. 

Give this a good checking over and provide advise for what I should do further to improve things for the next one

Can we do something about the boards that need  FORCE_SOFT_SPI ?

I forgot to add a few interfaces...  
custom is needed for pins_BTT_SKR_E3_DIP.h
pins_BTT_SKR_MINI_E3_common.h
pins_CREALITY_V4.h
and two for pins_BTT_SKR_MINI_E3_V3_0.h

Ill look at adding these and try again..
