### PR TITLE
Remove redundant ENABLED for HAS_LIN_ADVANCE_K and only planner.recalculate_max_e_jerk if HAS_LINEAR_E_JERK

### DIFF
--- a/Marlin/src/lcd/dwin/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/dwin/jyersui/dwin.cpp
@@ -2325,7 +2325,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
       #define MOTION_JERK (MOTION_ACCEL + ENABLED(CLASSIC_JERK))
       #define MOTION_STEPS (MOTION_JERK + 1)
       #define MOTION_FLOW (MOTION_STEPS + ENABLED(HAS_HOTEND))
-      #define MOTION_LA (MOTION_FLOW + ENABLED(LIN_ADVANCE))
+      #define MOTION_LA (MOTION_FLOW + HAS_LIN_ADVANCE_K)
       #define MOTION_TOTAL MOTION_LA
 
       switch (item) {
@@ -2383,7 +2383,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
             break;
         #endif
 
-        #if ENABLED(LIN_ADVANCE)
+        #if HAS_LIN_ADVANCE_K
           case MOTION_LA:
             if (draw) {
               drawMenuItem(row, ICON_MaxAccelerated, GET_TEXT_F(MSG_ADVANCE_K));
@@ -2845,7 +2845,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
       #define ADVANCED_PROBE (ADVANCED_BEEPER + ENABLED(HAS_BED_PROBE))
       #define ADVANCED_TMC (ADVANCED_PROBE + ENABLED(HAS_TRINAMIC_CONFIG))
       #define ADVANCED_CORNER (ADVANCED_TMC + 1)
-      #define ADVANCED_LA (ADVANCED_CORNER + ENABLED(LIN_ADVANCE))
+      #define ADVANCED_LA (ADVANCED_CORNER + HAS_LIN_ADVANCE_K)
       #define ADVANCED_LOAD (ADVANCED_LA + ENABLED(ADVANCED_PAUSE_FEATURE))
       #define ADVANCED_UNLOAD (ADVANCED_LOAD + ENABLED(ADVANCED_PAUSE_FEATURE))
       #define ADVANCED_COLD_EXTRUDE  (ADVANCED_UNLOAD + ENABLED(PREVENT_COLD_EXTRUSION))
@@ -2902,7 +2902,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
             modifyValue(corner_pos, 1, 100, 10);
           break;
 
-        #if ENABLED(LIN_ADVANCE)
+        #if HAS_LIN_ADVANCE_K
           case ADVANCED_LA:
             if (draw) {
               drawMenuItem(row, ICON_MaxAccelerated, GET_TEXT_F(MSG_ADVANCE_K));
@@ -3819,7 +3819,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
       #define TUNE_ZOFFSET (TUNE_FAN + ENABLED(HAS_ZOFFSET_ITEM))
       #define TUNE_ZUP (TUNE_ZOFFSET + ENABLED(HAS_ZOFFSET_ITEM))
       #define TUNE_ZDOWN (TUNE_ZUP + ENABLED(HAS_ZOFFSET_ITEM))
-      #define TUNE_LA (TUNE_ZDOWN + ENABLED(LIN_ADVANCE))
+      #define TUNE_LA (TUNE_ZDOWN + HAS_LIN_ADVANCE_K)
       #define TUNE_CHANGEFIL (TUNE_LA + ENABLED(FILAMENT_LOAD_UNLOAD_GCODES))
       #define TUNE_FWRETRACT (TUNE_CHANGEFIL + ENABLED(FWRETRACT))
       #define TUNE_FILSENSORENABLED (TUNE_FWRETRACT + ENABLED(HAS_FILAMENT_SENSOR))
@@ -3913,7 +3913,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
             break;
         #endif
 
-        #if ENABLED(LIN_ADVANCE)
+        #if HAS_LIN_ADVANCE_K
           case TUNE_LA:
             if (draw) {
               drawMenuItem(row, ICON_MaxAccelerated, GET_TEXT_F(MSG_ADVANCE_K));

--- a/Marlin/src/lcd/dwin/proui/dwin.cpp
+++ b/Marlin/src/lcd/dwin/proui/dwin.cpp
@@ -2691,7 +2691,7 @@ void applyMaxAccel() { planner.set_max_acceleration(hmiValue.axis, menuData.valu
     void setMaxJerkE() { hmiValue.axis = E_AXIS; setFloatOnClick(min_jerk_edit_values.e, max_jerk_edit_values.e, UNITFDIGITS, planner.max_jerk.e, applyMaxJerk); }
   #endif
 #elif HAS_JUNCTION_DEVIATION
-  void applyJDmm() { TERN_(LIN_ADVANCE, planner.recalculate_max_e_jerk()); }
+  void applyJDmm() { TERN_(HAS_LINEAR_E_JERK, planner.recalculate_max_e_jerk()); }
   void setJDmm() { setPFloatOnClick(MIN_JD_MM, MAX_JD_MM, 3, applyJDmm); }
 #endif
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/bioprinter/advanced_settings.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/bioprinter/advanced_settings.cpp
@@ -58,7 +58,7 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
       .tag(10) .button(BTN_POS(2,4), BTN_SIZE(1,1), GET_TEXT_F(TERN(HAS_JUNCTION_DEVIATION, MSG_JUNCTION_DEVIATION, MSG_JERK)))
                .enabled(ENABLED(BACKLASH_GCODE))
       .tag(11) .button(BTN_POS(2,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_BACKLASH))
-               .enabled(ENABLED(HAS_LIN_ADVANCE_K))
+               .enabled(HAS_LIN_ADVANCE_K)
       .tag(12) .button(BTN_POS(1,6), BTN_SIZE(2,1), GET_TEXT_F(MSG_LINEAR_ADVANCE))
       .tag(13) .button(BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXT_F(MSG_INTERFACE))
       .tag(14) .button(BTN_POS(1,8), BTN_SIZE(2,1), GET_TEXT_F(MSG_RESTORE_DEFAULTS))
@@ -88,7 +88,7 @@ bool AdvancedSettingsMenu::onTouchEnd(uint8_t tag) {
     #if ENABLED(BACKLASH_GCODE)
       case 11: GOTO_SCREEN(BacklashCompensationScreen);    break;
     #endif
-    #if ENABLED(HAS_LIN_ADVANCE_K)
+    #if HAS_LIN_ADVANCE_K
       case 12: GOTO_SCREEN(LinearAdvanceScreen);           break;
     #endif
     case 13: GOTO_SCREEN(InterfaceSettingsScreen);         break;

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/cocoa_press/advanced_settings_menu.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/cocoa_press/advanced_settings_menu.cpp
@@ -57,7 +57,7 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
       .tag(2) .button(STEPS_PER_MM_POS,       GET_TEXT_F(MSG_STEPS_PER_MM))
               .enabled(ENABLED(HAS_TRINAMIC_CONFIG))
       .tag(3) .button(TMC_CURRENT_POS,        GET_TEXT_F(MSG_TMC_CURRENT))
-              .enabled(ENABLED(HAS_LIN_ADVANCE_K))
+              .enabled(HAS_LIN_ADVANCE_K)
       .tag(4) .button(LIN_ADVANCE_POS,        GET_TEXT_F(MSG_LINEAR_ADVANCE))
       .tag(5) .button(VELOCITY_POS,           GET_TEXT_F(MSG_MAX_SPEED_NO_UNITS))
       .tag(6) .button(ACCELERATION_POS,       GET_TEXT_F(MSG_ACCELERATION))

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/filament_menu.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/filament_menu.cpp
@@ -60,7 +60,7 @@ void FilamentMenu::onRedraw(draw_mode_t what) {
        .font(font_medium).colors(normal_btn)
        .enabled(ENABLED(HAS_FILAMENT_SENSOR))
        .tag(2).button(RUNOUT_SENSOR_POS, GET_TEXT_F(MSG_RUNOUT_SENSOR))
-       .enabled(ENABLED(HAS_LIN_ADVANCE_K))
+       .enabled(HAS_LIN_ADVANCE_K)
        .tag(3).button(LIN_ADVANCE_POS, GET_TEXT_F(MSG_LINEAR_ADVANCE))
        .colors(action_btn)
        .tag(1).button(BACK_POS, GET_TEXT_F(MSG_BUTTON_DONE));

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -676,7 +676,7 @@ namespace ExtUI {
 
     void setJunctionDeviation_mm(const float value) {
       planner.junction_deviation_mm = constrain(value, 0.001, 0.3);
-      TERN_(HAS_LIN_ADVANCE_K, planner.recalculate_max_e_jerk());
+      TERN_(HAS_LINEAR_E_JERK, planner.recalculate_max_e_jerk());
     }
 
   #else


### PR DESCRIPTION
Remove redundant ENABLED for HAS_LIN_ADVANCE_K and only planner.recalculate_max_e_jerk if HAS_LINEAR_E_JERK
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
